### PR TITLE
Add JSON import template

### DIFF
--- a/import-template.json
+++ b/import-template.json
@@ -1,0 +1,52 @@
+{
+  "clients": [
+    {
+      "id": "", 
+      "first": "", 
+      "last": "", 
+      "email": "", 
+      "phone": "", 
+      "notes": "", 
+      "birthday": "", 
+      "styles": [], 
+      "brands": [], 
+      "sizeShirt": "", 
+      "sizeDress": "", 
+      "sizePant": "", 
+      "sizeShoe": "", 
+      "initialSale": 0
+    }
+  ],
+  "appointments": [
+    {
+      "id": "", 
+      "title": "", 
+      "date": "", 
+      "status": "", 
+      "notes": "", 
+      "clientIds": []
+    }
+  ],
+  "sales": [
+    {
+      "id": "", 
+      "clientId": "", 
+      "amount": 0, 
+      "date": "", 
+      "desc": "", 
+      "appointmentId": ""
+    }
+  ],
+  "outreach": [
+    {
+      "id": "", 
+      "title": "", 
+      "date": "", 
+      "category": "", 
+      "notes": "", 
+      "status": "", 
+      "clientIds": [], 
+      "appointmentId": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON template outlining required structure for clients, appointments, sales, and outreach data

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e98b6170c8326afe4639356a6f1fd